### PR TITLE
Add compressed byte output and new CLI options for branching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tags
 build/
 *.swp
 *~
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 option(ROOTREADSPEED_TESTS "Set to ON to build unit tests." OFF)
 
 message(STATUS "Looking for ROOT")
-find_package(ROOT REQUIRED COMPONENTS Tree RIO TreePlayer)
+find_package(ROOT REQUIRED COMPONENTS Tree RIO TreePlayer ROOTDataFrame)
 message(STATUS "ROOT ${ROOT_VERSION} found at ${ROOT_BINDIR}")
 
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(ReadSpeed INTERFACE)
 add_library(ReadSpeed::ReadSpeed ALIAS ReadSpeed)
 target_sources(ReadSpeed INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/ReadSpeed.hxx)
-target_link_libraries(ReadSpeed INTERFACE ROOT::RIO ROOT::Tree ROOT::TreePlayer)
+target_link_libraries(ReadSpeed INTERFACE ROOT::RIO ROOT::Tree ROOT::TreePlayer ROOT::ROOTDataFrame)
 target_include_directories(ReadSpeed INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(root-readspeed root_readspeed.cxx)

--- a/src/ReadSpeed.hxx
+++ b/src/ReadSpeed.hxx
@@ -34,7 +34,7 @@ struct Data {
    /// Branches to read.
    std::vector<std::string> fBranchNames;
    /// If the branch names should use regex matching.
-   bool fUseRegex = true;
+   bool fUseRegex = false;
 };
 
 struct Result {

--- a/src/ReadSpeed.hxx
+++ b/src/ReadSpeed.hxx
@@ -243,8 +243,8 @@ inline Result EvalThroughputMT(const Data &d, unsigned nThreads)
 
    // for each file, for each range, spawn a reading task
    auto sumBytes = [](const std::vector<ByteData> &bytesData) -> ByteData {
-      const auto uncompressedBytes = std::accumulate(bytesData.begin(), bytesData.end(), 0ull, [](int, const ByteData& o){ return o.fUncompressedBytesRead; });
-      const auto compressedBytes = std::accumulate(bytesData.begin(), bytesData.end(), 0ull, [](int, const ByteData& o){ return o.fCompressedBytesRead; });
+      const auto uncompressedBytes = std::accumulate(bytesData.begin(), bytesData.end(), 0ull, [](ULong64_t sum, const ByteData& o){ return sum + o.fUncompressedBytesRead; });
+      const auto compressedBytes = std::accumulate(bytesData.begin(), bytesData.end(), 0ull, [](ULong64_t sum, const ByteData& o){ return sum + o.fCompressedBytesRead; });
 
       return { uncompressedBytes, compressedBytes };
    };

--- a/src/ReadSpeed.hxx
+++ b/src/ReadSpeed.hxx
@@ -98,13 +98,12 @@ std::vector<std::string> GetMatchingBranchNames(const std::string &fileName, con
    if (branchNames.empty())
       throw std::runtime_error("Provided branch regexes didn't match any branches in the tree.");
    if (usedRegexes.size() != regexes.size()) {
-      std::stringstream errStream;
-      errStream << "The following regexes didn't match any branches in the tree, this is probably unintended:\n";
+      std::string errString = "The following regexes didn't match any branches in the tree, this is probably unintended:\n";
       for (const auto &regex : regexes) {
          if (usedRegexes.find(regex) == usedRegexes.end())
-            errStream << '\t' + regex << '\n';
+            errString += '\t' + regex + '\n';
       }
-      throw std::runtime_error(errStream.str());
+      throw std::runtime_error(errString);
    }
 
    return branchNames;
@@ -132,7 +131,7 @@ inline ByteData ReadTree(const std::string &treeName, const std::string &fileNam
    t->SetBranchStatus("*", 0);
 
    std::vector<TBranch *> branches;
-   for (auto &bName : branchNames) {
+   for (const auto &bName : branchNames) {
       auto *b = t->GetBranch(bName.c_str());
       if (b == nullptr)
          throw std::runtime_error("Could not retrieve branch '" + bName + "' from tree '" + t->GetName() +

--- a/src/ReadSpeed.hxx
+++ b/src/ReadSpeed.hxx
@@ -98,7 +98,8 @@ std::vector<std::string> GetMatchingBranchNames(const std::string &fileName, con
    if (branchNames.empty())
       throw std::runtime_error("Provided branch regexes didn't match any branches in the tree.");
    if (usedRegexes.size() != regexes.size()) {
-      std::string errString = "The following regexes didn't match any branches in the tree, this is probably unintended:\n";
+      std::string errString =
+         "The following regexes didn't match any branches in the tree, this is probably unintended:\n";
       for (const auto &regex : regexes) {
          if (usedRegexes.find(regex) == usedRegexes.end())
             errString += '\t' + regex + '\n';

--- a/src/root_readspeed.cxx
+++ b/src/root_readspeed.cxx
@@ -22,7 +22,8 @@ void PrintThroughput(const Result &r)
    std::cout << "Uncompressed data read:\t\t" << r.fUncompressedBytesRead << " bytes\n";
    std::cout << "Compressed data read:\t\t" << r.fCompressedBytesRead << " bytes\n";
 
-   std::cout << "Throughput:\t\t\t" << r.fUncompressedBytesRead / r.fRealTime / 1024 / 1024 << " MB/s\n";
+   std::cout << "Uncompressed throughput:\t" << r.fUncompressedBytesRead / r.fRealTime / 1024 / 1024 << " MB/s\n";
+   std::cout << "Compressed throughput:\t\t" << r.fCompressedBytesRead / r.fRealTime / 1024 / 1024 << " MB/s\n";
 }
 
 struct Args {

--- a/src/root_readspeed.cxx
+++ b/src/root_readspeed.cxx
@@ -90,8 +90,8 @@ int main(int argc, char **argv)
    if (args.fAllBranches) {
       if (!args.fData.fBranchNames.empty())
          throw std::runtime_error("Can't use 'all-branches' argument and specify branches as well.");
-      
-      args.fData.fBranchNames = { ".*" };
+
+      args.fData.fBranchNames = {".*"};
       args.fData.fUseRegex = true;
    }
 

--- a/src/root_readspeed.cxx
+++ b/src/root_readspeed.cxx
@@ -40,8 +40,8 @@ Args ParseArgs(int argc, char **argv)
       std::cout << "Usage:\n"
                 << "  root-readspeed --trees tname1 [tname2 ...]\n"
                 << "                 --files fname1 [fname2 ...]\n"
-                << "                 (--all-branches | --branches bname1 [bname2 ...])\n"
-                << "                 [--regex-off]\n"
+                << "                 (--all-branches | --branches bname1 [bname2 ...] | --branches-regex bregex1 "
+                   "[bregex2 ...])\n"
                 << "                 [--threads nthreads]\n"
                 << "  root-readspeed (--help|-h)\n";
       return {};
@@ -49,24 +49,49 @@ Args ParseArgs(int argc, char **argv)
 
    Data d;
    unsigned int nThreads = 0;
-   bool allBranches = false;
 
    enum class EArgState { kNone, kTrees, kFiles, kBranches, kThreads } argState = EArgState::kNone;
+   enum class EBranchState { kNone, kRegular, kRegex, kAll } branchState = EBranchState::kNone;
+
    for (int i = 1; i < argc; ++i) {
-      if (std::strcmp(argv[i], "--trees") == 0)
+      std::string arg(argv[i]);
+
+      if (arg.compare("--trees") == 0) {
          argState = EArgState::kTrees;
-      else if (std::strcmp(argv[i], "--files") == 0)
+      } else if (arg.compare("--files") == 0) {
          argState = EArgState::kFiles;
-      else if (std::strcmp(argv[i], "--branches") == 0)
+      } else if (arg.compare("--all-branches") == 0) {
+         argState = EArgState::kNone;
+         if (branchState != EBranchState::kNone && branchState != EBranchState::kAll) {
+            std::cerr << "Options --all-branches, --branches, and --branches-regex are mutually exclusive. You can use "
+                         "only one."
+                      << std::endl;
+            return {};
+         }
+         branchState = EBranchState::kAll;
+         d.fUseRegex = true;
+         d.fBranchNames = {".*"};
+      } else if (arg.compare("--branches") == 0) {
          argState = EArgState::kBranches;
-      else if (std::strcmp(argv[i], "--threads") == 0)
+         if (branchState != EBranchState::kNone && branchState != EBranchState::kRegular) {
+            std::cerr << "Options --all-branches, --branches, and --branches-regex are mutually exclusive. You can use "
+                         "only one."
+                      << std::endl;
+            return {};
+         }
+         branchState = EBranchState::kRegular;
+      } else if (arg.compare("--branches-regex") == 0) {
+         argState = EArgState::kBranches;
+         if (branchState != EBranchState::kNone && branchState != EBranchState::kRegex) {
+            std::cerr << "Options --all-branches, --branches, and --branches-regex are mutually exclusive. You can use "
+                         "only one."
+                      << std::endl;
+            return {};
+         }
+         branchState = EBranchState::kRegex;
+         d.fUseRegex = true;
+      } else if (arg.compare("--threads") == 0) {
          argState = EArgState::kThreads;
-      else if (std::strcmp(argv[i], "--regex-off") == 0) {
-         argState = EArgState::kNone;
-         d.fUseRegex = false;
-      } else if (std::strcmp(argv[i], "--all-branches") == 0) {
-         argState = EArgState::kNone;
-         allBranches = true;
       } else {
          switch (argState) {
          case EArgState::kTrees: d.fTreeNames.emplace_back(argv[i]); break;
@@ -78,7 +103,7 @@ Args ParseArgs(int argc, char **argv)
       }
    }
 
-   return Args{std::move(d), nThreads, allBranches, /*fShouldRun=*/true};
+   return Args{std::move(d), nThreads, branchState == EBranchState::kAll, /*fShouldRun=*/true};
 }
 
 int main(int argc, char **argv)
@@ -87,14 +112,7 @@ int main(int argc, char **argv)
 
    if (!args.fShouldRun)
       return 1; // ParseArgs has printed the --help, has run the --test or has encountered an issue and logged about it
-   if (args.fAllBranches) {
-      if (!args.fData.fBranchNames.empty())
-         throw std::runtime_error("Can't use 'all-branches' argument and specify branches as well.");
-
-      args.fData.fBranchNames = {".*"};
-      args.fData.fUseRegex = true;
-   }
-
+   
    PrintThroughput(EvalThroughput(args.fData, args.fNThreads));
 
    return 0;

--- a/src/root_readspeed.cxx
+++ b/src/root_readspeed.cxx
@@ -38,6 +38,7 @@ Args ParseArgs(int argc, char **argv)
       std::cout << "Usage:\n"
                 << "  root-readspeed --trees tname1 [tname2 ...] --files fname1 [fname2 ...]\n"
                 << "                 --branches bname1 [bname2 ...] [--threads nthreads]\n"
+                << "                 [--regexOff]"
                 << "  root-readspeed (--help|-h)\n";
       return {};
    }
@@ -55,7 +56,10 @@ Args ParseArgs(int argc, char **argv)
          argState = EArgState::kBranches;
       else if (std::strcmp(argv[i], "--threads") == 0)
          argState = EArgState::kThreads;
-      else {
+      else if (std::strcmp(argv[i], "--regexOff") == 0) {
+         argState = EArgState::kNone;
+         d.fUseRegex = false;
+      } else {
          switch (argState) {
          case EArgState::kTrees: d.fTreeNames.emplace_back(argv[i]); break;
          case EArgState::kFiles: d.fFileNames.emplace_back(argv[i]); break;

--- a/src/root_readspeed.cxx
+++ b/src/root_readspeed.cxx
@@ -20,6 +20,7 @@ void PrintThroughput(const Result &r)
    std::cout << "Real time:\t\t\t" << r.fRealTime << " s\n";
    std::cout << "CPU time:\t\t\t" << r.fCpuTime << " s\n";
    std::cout << "Uncompressed data read:\t\t" << r.fUncompressedBytesRead << " bytes\n";
+   std::cout << "Compressed data read:\t\t" << r.fCompressedBytesRead << " bytes\n";
 
    std::cout << "Throughput:\t\t\t" << r.fUncompressedBytesRead / r.fRealTime / 1024 / 1024 << " MB/s\n";
 }

--- a/src/root_readspeed.cxx
+++ b/src/root_readspeed.cxx
@@ -52,6 +52,8 @@ Args ParseArgs(int argc, char **argv)
 
    enum class EArgState { kNone, kTrees, kFiles, kBranches, kThreads } argState = EArgState::kNone;
    enum class EBranchState { kNone, kRegular, kRegex, kAll } branchState = EBranchState::kNone;
+   const auto branchOptionsErrMsg =
+      "Options --all-branches, --branches, and --branches-regex are mutually exclusive. You can use only one.\n";
 
    for (int i = 1; i < argc; ++i) {
       std::string arg(argv[i]);
@@ -63,9 +65,7 @@ Args ParseArgs(int argc, char **argv)
       } else if (arg.compare("--all-branches") == 0) {
          argState = EArgState::kNone;
          if (branchState != EBranchState::kNone && branchState != EBranchState::kAll) {
-            std::cerr << "Options --all-branches, --branches, and --branches-regex are mutually exclusive. You can use "
-                         "only one."
-                      << std::endl;
+            std::cerr << branchOptionsErrMsg;
             return {};
          }
          branchState = EBranchState::kAll;
@@ -74,18 +74,14 @@ Args ParseArgs(int argc, char **argv)
       } else if (arg.compare("--branches") == 0) {
          argState = EArgState::kBranches;
          if (branchState != EBranchState::kNone && branchState != EBranchState::kRegular) {
-            std::cerr << "Options --all-branches, --branches, and --branches-regex are mutually exclusive. You can use "
-                         "only one."
-                      << std::endl;
+            std::cerr << branchOptionsErrMsg;
             return {};
          }
          branchState = EBranchState::kRegular;
       } else if (arg.compare("--branches-regex") == 0) {
          argState = EArgState::kBranches;
          if (branchState != EBranchState::kNone && branchState != EBranchState::kRegex) {
-            std::cerr << "Options --all-branches, --branches, and --branches-regex are mutually exclusive. You can use "
-                         "only one."
-                      << std::endl;
+            std::cerr << branchOptionsErrMsg;
             return {};
          }
          branchState = EBranchState::kRegex;
@@ -112,7 +108,7 @@ int main(int argc, char **argv)
 
    if (!args.fShouldRun)
       return 1; // ParseArgs has printed the --help, has run the --test or has encountered an issue and logged about it
-   
+
    PrintThroughput(EvalThroughput(args.fData, args.fNThreads));
 
    return 0;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -50,7 +50,7 @@ TEST_CASE("Integration test")
 
 TEST_CASE("Branch test")
 {
-   RequireFile("test3.root", { "x", "x_branch", "y_brunch", "mismatched" });
+   RequireFile("test3.root", {"x", "x_branch", "y_brunch", "mismatched"});
 
    SUBCASE("Single branch")
    {
@@ -75,6 +75,6 @@ TEST_CASE("Branch test")
       CHECK_MESSAGE(result.fUncompressedBytesRead == 160000000, "Wrong number of uncompressed bytes read");
       CHECK_MESSAGE(result.fCompressedBytesRead == 1316837, "Wrong number of compressed bytes read");
    }
-   
+
    gSystem->Unlink("test3.root");
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -35,11 +35,13 @@ TEST_CASE("Integration test")
    {
       const auto result = EvalThroughput({{"t"}, {"test1.root", "test2.root"}, {"x"}}, 0);
       CHECK_MESSAGE(result.fUncompressedBytesRead == 80000000, "Wrong number of bytes read");
+      CHECK_MESSAGE(result.fCompressedBytesRead == 643934, "Wrong number of compressed bytes read");
    }
    SUBCASE("Multi-thread run")
    {
       const auto result = EvalThroughput({{"t"}, {"test1.root", "test2.root"}, {"x"}}, 2);
       CHECK_MESSAGE(result.fUncompressedBytesRead == 80000000, "Wrong number of bytes read");
+      CHECK_MESSAGE(result.fCompressedBytesRead == 643934, "Wrong number of compressed bytes read");
    }
 
    gSystem->Unlink("test1.root");
@@ -53,12 +55,14 @@ TEST_CASE("Branch test")
    SUBCASE("Single branch")
    {
       const auto result = EvalThroughput({{"t"}, {"test3.root"}, {"x"}}, 0);
-      CHECK_MESSAGE(result.fUncompressedBytesRead == 40000000, "Wrong number of bytes read");
+      CHECK_MESSAGE(result.fUncompressedBytesRead == 40000000, "Wrong number of uncompressed bytes read");
+      CHECK_MESSAGE(result.fCompressedBytesRead == 321967, "Wrong number of compressed bytes read");
    }
    SUBCASE("Pattern branches")
    {
       const auto result = EvalThroughput({{"t"}, {"test3.root"}, {"(x|y)_.*nch"}, true}, 0);
-      CHECK_MESSAGE(result.fUncompressedBytesRead == 80000000, "Wrong number of bytes read");
+      CHECK_MESSAGE(result.fUncompressedBytesRead == 80000000, "Wrong number of uncompressed bytes read");
+      CHECK_MESSAGE(result.fCompressedBytesRead == 661576, "Wrong number of compressed bytes read");
    }
    SUBCASE("No matches")
    {
@@ -68,7 +72,8 @@ TEST_CASE("Branch test")
    SUBCASE("All branches")
    {
       const auto result = EvalThroughput({{"t"}, {"test3.root"}, {".*"}, true}, 0);
-      CHECK_MESSAGE(result.fUncompressedBytesRead == 160000000, "Wrong number of bytes read");
+      CHECK_MESSAGE(result.fUncompressedBytesRead == 160000000, "Wrong number of uncompressed bytes read");
+      CHECK_MESSAGE(result.fCompressedBytesRead == 1316837, "Wrong number of compressed bytes read");
    }
    
    gSystem->Unlink("test3.root");

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -57,16 +57,17 @@ TEST_CASE("Branch test")
    }
    SUBCASE("Pattern branches")
    {
-      const auto result = EvalThroughput({{"t"}, {"test3.root"}, {"(x|y)_.*nch"}}, 0);
+      const auto result = EvalThroughput({{"t"}, {"test3.root"}, {"(x|y)_.*nch"}, true}, 0);
       CHECK_MESSAGE(result.fUncompressedBytesRead == 80000000, "Wrong number of bytes read");
    }
    SUBCASE("No matches")
    {
-      CHECK_THROWS(EvalThroughput({{"t"}, {"test3.root"}, {"."}, false}, 0));
+      CHECK_THROWS(EvalThroughput({{"t"}, {"test3.root"}, {"x_.*"}, false}, 0));
+      CHECK_THROWS(EvalThroughput({{"t"}, {"test3.root"}, {"z_.*"}, true}, 0));
    }
    SUBCASE("All branches")
    {
-      const auto result = EvalThroughput({{"t"}, {"test3.root"}, {".*"}}, 0);
+      const auto result = EvalThroughput({{"t"}, {"test3.root"}, {".*"}, true}, 0);
       CHECK_MESSAGE(result.fUncompressedBytesRead == 160000000, "Wrong number of bytes read");
    }
    

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -60,10 +60,9 @@ TEST_CASE("Branch test")
       const auto result = EvalThroughput({{"t"}, {"test3.root"}, {"(x|y)_.*nch"}}, 0);
       CHECK_MESSAGE(result.fUncompressedBytesRead == 80000000, "Wrong number of bytes read");
    }
-   SUBCASE("No regex")
+   SUBCASE("No matches")
    {
-      const auto result = EvalThroughput({{"t"}, {"test3.root"}, {"."}, false}, 0);
-      CHECK_MESSAGE(result.fUncompressedBytesRead == 0, "Wrong number of bytes read");
+      CHECK_THROWS(EvalThroughput({{"t"}, {"test3.root"}, {"."}, false}, 0));
    }
    SUBCASE("All branches")
    {

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -63,7 +63,12 @@ TEST_CASE("Branch test")
    SUBCASE("No regex")
    {
       const auto result = EvalThroughput({{"t"}, {"test3.root"}, {"."}, false}, 0);
-      CHECK_MESSAGE(result.fUncompressedBytesRead == 00000000, "Wrong number of bytes read");
+      CHECK_MESSAGE(result.fUncompressedBytesRead == 0, "Wrong number of bytes read");
+   }
+   SUBCASE("All branches")
+   {
+      const auto result = EvalThroughput({{"t"}, {"test3.root"}, {".*"}}, 0);
+      CHECK_MESSAGE(result.fUncompressedBytesRead == 160000000, "Wrong number of bytes read");
    }
    
    gSystem->Unlink("test3.root");

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -17,7 +17,7 @@ void RequireFile(const std::string &fname, const std::vector<std::string> &branc
    TTree t("t", "t");
 
    int var = 42;
-   for (const auto b : branchNames) {
+   for (const auto &b : branchNames) {
       t.Branch(b.c_str(), &var);
    }
 


### PR DESCRIPTION
Adds the following features:
- Now shows the total number of compressed bytes read as part of the info log.
- Adds the ability to use regex in branch names using the `--branches` CLI argument. Includes another flag `--no-regex` to disable it.
- Adds an `--all-branches` flag to use all branches, essentially a shorthand for `--branches ".*"` with regex forced on.
- Adds extra testing for using regex branch names.