### PR TITLE
Add tests for invalid arguments

### DIFF
--- a/src/ReadSpeed.cxx
+++ b/src/ReadSpeed.cxx
@@ -25,7 +25,7 @@ std::vector<std::string> ReadSpeed::GetMatchingBranchNames(const std::string &fi
                                                            const std::vector<std::string> &regexes)
 {
    TFile *f = TFile::Open(fileName.c_str());
-   if (f->IsZombie())
+   if (f == nullptr || f->IsZombie())
       throw std::runtime_error("Could not open file '" + fileName + '\'');
    std::unique_ptr<TTree> t(f->Get<TTree>(treeName.c_str()));
    if (t == nullptr)
@@ -80,7 +80,7 @@ ByteData ReadSpeed::ReadTree(const std::string &treeName, const std::string &fil
       f = TFile::Open(fileName.c_str()); // TFile::Open uses plug-ins if needed
    }
 
-   if (f->IsZombie())
+   if (f == nullptr || f->IsZombie())
       throw std::runtime_error("Could not open file '" + fileName + '\'');
    std::unique_ptr<TTree> t(f->Get<TTree>(treeName.c_str()));
    if (t == nullptr)
@@ -157,7 +157,7 @@ std::vector<std::vector<EntryRange>> ReadSpeed::GetClusters(const Data &d)
    for (auto fileIdx = 0u; fileIdx < nFiles; ++fileIdx) {
       const auto &fileName = d.fFileNames[fileIdx];
       std::unique_ptr<TFile> f(TFile::Open(fileName.c_str()));
-      if (f->IsZombie())
+      if (f == nullptr || f->IsZombie())
          throw std::runtime_error("There was a problem opening file '" + fileName + '\'');
       const auto &treeName = d.fTreeNames.size() > 1 ? d.fTreeNames[fileIdx] : d.fTreeNames[0];
       auto *t = f->Get<TTree>(treeName.c_str()); // TFile owns this TTree

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -46,6 +46,20 @@ TEST_CASE("Integration test")
       CHECK_MESSAGE(result.fUncompressedBytesRead == 80000000, "Wrong number of bytes read");
       CHECK_MESSAGE(result.fCompressedBytesRead == 643934, "Wrong number of compressed bytes read");
    }
+   SUBCASE("Invalid filename")
+   {
+      CHECK_THROWS_WITH(EvalThroughput({{"t"}, {"test_fake.root"}, {"x"}}, 0), "Could not open file 'test_fake.root'");
+   }
+   SUBCASE("Invalid tree")
+   {
+      CHECK_THROWS_WITH(EvalThroughput({{"t_fake"}, {"test1.root"}, {"x"}}, 0),
+                        "Could not retrieve tree 't_fake' from file 'test1.root'");
+   }
+   SUBCASE("Invalid branch")
+   {
+      CHECK_THROWS_WITH(EvalThroughput({{"t"}, {"test1.root"}, {"z"}}, 0),
+                        "Could not retrieve branch 'z' from tree 't' in file 'test1.root'");
+   }
 
    gSystem->Unlink("test1.root");
    gSystem->Unlink("test2.root");


### PR DESCRIPTION
Ensures that the programme will correctly error out if:
- A provided file does not exist.
- A provided tree does not exist in a file.
- A provided branch does not exist in a tree.

Adds initial test cases for all of the above.

Issue: #9 