### PR TITLE
Add custom tasks per worker CLI arg

### DIFF
--- a/src/ReadSpeed.cxx
+++ b/src/ReadSpeed.cxx
@@ -235,6 +235,11 @@ Result ReadSpeed::EvalThroughputMT(const Data &d, unsigned nThreads)
    const auto rangesPerFile = MergeClusters(GetClusters(d), maxTasksPerFile);
    clsw.Stop();
 
+   size_t nranges = 0;
+   for (const auto &r : rangesPerFile)
+      nranges += r.size();
+   std::cout << "Total number of entry ranges: " << nranges << '\n';
+
    auto treeIdx = 0;
    std::vector<std::vector<std::string>> fileBranchNames;
    for (const auto &fName : d.fFileNames) {

--- a/src/ReadSpeed.cxx
+++ b/src/ReadSpeed.cxx
@@ -235,10 +235,9 @@ Result ReadSpeed::EvalThroughputMT(const Data &d, unsigned nThreads)
    const auto rangesPerFile = MergeClusters(GetClusters(d), maxTasksPerFile);
    clsw.Stop();
 
-   size_t nranges = 0;
-   for (const auto &r : rangesPerFile)
-      nranges += r.size();
-   std::cout << "Total number of entry ranges: " << nranges << '\n';
+   size_t nranges =
+      std::accumulate(rangesPerFile.begin(), rangesPerFile.end(), 0u, [](size_t s, auto &r) { return s + r.size(); });
+   std::cout << "Total number of tasks: " << nranges << '\n';
 
    auto treeIdx = 0;
    std::vector<std::vector<std::string>> fileBranchNames;

--- a/src/ReadSpeedCLI.cxx
+++ b/src/ReadSpeedCLI.cxx
@@ -12,8 +12,6 @@ using namespace ReadSpeed;
 
 void ReadSpeed::PrintThroughput(const Result &r)
 {
-   const uint effectiveThreads = std::max(r.fThreadPoolSize, 1u);
-
    std::cout << "Thread pool size:\t\t" << r.fThreadPoolSize << '\n';
 
    if (r.fMTSetupRealTime > 0.) {
@@ -26,6 +24,8 @@ void ReadSpeed::PrintThroughput(const Result &r)
 
    std::cout << "Uncompressed data read:\t\t" << r.fUncompressedBytesRead << " bytes\n";
    std::cout << "Compressed data read:\t\t" << r.fCompressedBytesRead << " bytes\n";
+
+   const uint effectiveThreads = std::max(r.fThreadPoolSize, 1u);
 
    std::cout << "Uncompressed throughput:\t" << r.fUncompressedBytesRead / r.fRealTime / 1024 / 1024 << " MB/s\n";
    std::cout << "\t\t\t\t" << r.fUncompressedBytesRead / r.fRealTime / 1024 / 1024 / effectiveThreads
@@ -90,6 +90,8 @@ Args ReadSpeed::ParseArgs(const std::vector<std::string> &args)
          d.fUseRegex = true;
       } else if (arg == "--threads") {
          argState = EArgState::kThreads;
+      } else if (arg == "--tasks-per-worker") {
+         argState = EArgState::kTasksPerWorkerHint;
       } else if (arg[0] == '-') {
          std::cerr << "Unrecognized option '" << arg << "'\n";
          return {};

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -247,7 +247,7 @@ TEST_CASE("CLI test")
       const auto parsedArgs = ParseArgs(allArgs);
       const auto newTasksPerWorker = ROOT::TTreeProcessorMT::GetTasksPerWorkerHint();
 
-      CHECK_MESSAGE(parsedArgs.fShouldRun, "Programme not running when given valid arguments");
+      CHECK_MESSAGE(parsedArgs.fShouldRun, "Program not running when given valid arguments");
       CHECK_MESSAGE(newTasksPerWorker == oldTasksPerWorker + 10, "Tasks per worker hint not updated correctly");
    }
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -6,6 +6,7 @@
 #include "ReadSpeed.hxx"
 #include "ReadSpeedCLI.hxx"
 
+#include "ROOT/TTreeProcessorMT.hxx" // for TTreeProcessorMT::GetTasksPerWorkerHint
 #include "TFile.h"
 #include "TSystem.h"
 #include "TTree.h"
@@ -227,5 +228,26 @@ TEST_CASE("CLI test")
 
       CHECK_MESSAGE(parsedArgs.fShouldRun, "Program not running when given valid arguments");
       CHECK_MESSAGE(parsedArgs.fNThreads == threads, "Program not using the correct amount of threads");
+   }
+   SUBCASE("Multiple thread args")
+   {
+      const uint oldTasksPerWorker = ROOT::TTreeProcessorMT::GetTasksPerWorkerHint();
+      const std::vector<std::string> allArgs{
+         "root-readspeed",
+         "--files",
+         "file.root",
+         "--trees",
+         "t",
+         "--branches",
+         "x",
+         "--tasks-per-worker",
+         std::to_string(oldTasksPerWorker + 10),
+      };
+
+      const auto parsedArgs = ParseArgs(allArgs);
+      const auto newTasksPerWorker = ROOT::TTreeProcessorMT::GetTasksPerWorkerHint();
+
+      CHECK_MESSAGE(parsedArgs.fShouldRun, "Programme not running when given valid arguments");
+      CHECK_MESSAGE(newTasksPerWorker == oldTasksPerWorker + 10, "Tasks per worker hint not updated correctly");
    }
 }


### PR DESCRIPTION
Adds in a new CLI argument to set the number of tasks per worker hint on `TTreeProcessorMT`, and also logs some extra per thread information for throughput.

**NB**: This branch is based on the changes made in the PR #15, so it looks like there's more changes than there really are.

Copy of PR: #6 

Addresses: #12 